### PR TITLE
Add openai requirements

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -4,3 +4,5 @@ google-auth
 requests
 beautifulsoup4
 streamlit
+openai>=1.0.0
+google-search-results


### PR DESCRIPTION
## Summary
- declare the need for `openai>=1.0.0`
- add `google-search-results` to dependencies

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_684727ab51608322ae42c43bbe4ed60f